### PR TITLE
making source and complex_source optional

### DIFF
--- a/cobrakbase/core/kbasefba/fbamodel_builder.py
+++ b/cobrakbase/core/kbasefba/fbamodel_builder.py
@@ -232,7 +232,9 @@ class FBAModelBuilder:
                 if complex_id not in complex_groups:
                     complex_group = Group(complex_id)
                     notes["complex_note"] = complex_data["note"]
-                    notes["complex_source"] = complex_data["source"]
+                    complex_source=None
+                    if("complex_source" in complex_data):
+                        notes["complex_source"] = complex_data["source"]
                     for u in complex_data["modelReactionProteinSubunits"]:
                         role_id = u["role"]
                         features = ";".join(

--- a/cobrakbase/core/kbasefba/fbamodel_protein.py
+++ b/cobrakbase/core/kbasefba/fbamodel_protein.py
@@ -83,8 +83,11 @@ class ModelReactionProtein(Group):
             for o in data["modelReactionProteinSubunits"]
         ]
         complex_id = data.get("complex_ref")
+        data_source=None
+        if("source" in data):
+            data_source=data["source"]
         return ModelReactionProtein(
-            complex_id, data["note"], data["source"], subunits, complex_id
+            complex_id, data["note"], data_source, subunits, complex_id
         )
 
     def get_data(self):


### PR DESCRIPTION
The base could be changed here I'm not sure if there should be a `dev` branch but essentially, some parameters in some of the FBAModel subobjects are optional and aren't always created. If they're not there, then the code throws an error.