### PR TITLE
original Media object wont load without object_type string

### DIFF
--- a/cobrakbase/core/kbase_object_factory.py
+++ b/cobrakbase/core/kbase_object_factory.py
@@ -2,7 +2,7 @@ import json
 import logging
 from cobrakbase.kbase_object_info import KBaseObjectInfo
 from cobrakbase.core.kbaseobject import KBaseObject
-from cobrakbase.core.kbasebiochem import Media
+from cobrakbase.core.kbasebiochemmedia import KBaseBiochemMedia as Media
 from cobrakbase.core.kbasefba.fbamodel_builder import FBAModelBuilder
 from cobrakbase.core.kbasefba.newmodeltemplate_builder import NewModelTemplateBuilder
 from cobrakbase.core.kbasegenome.genome import KBaseGenome

--- a/cobrakbase/core/kbasebiochem/__init__.py
+++ b/cobrakbase/core/kbasebiochem/__init__.py
@@ -1,1 +1,1 @@
-from cobrakbase.core.kbasebiochem.media import Media
+from cobrakbase.core.kbasebiochemmedia import KBaseBiochemMedia as Media

--- a/cobrakbase/core/kbasefba/fbamodel.py
+++ b/cobrakbase/core/kbasefba/fbamodel.py
@@ -5,7 +5,7 @@ from typing import Union, Optional
 from cobra.core import Model, Reaction
 from cobrakbase.kbase_object_info import KBaseObjectInfo
 from cobrakbase.core.kbaseobject import KBaseObject
-from cobrakbase.core.kbasebiochem.media import Media
+from cobrakbase.core.kbasebiochemmedia import KBaseBiochemMedia as Media
 from cobrakbase.core.kbasefba.fbamodel_metabolite import ModelCompound
 from cobrakbase.core.kbasefba.fbamodel_reaction import ModelReaction
 from cobrakbase.core.kbasefba.fbamodel_biomass import Biomass


### PR DESCRIPTION
This simple script wouldn't work for me:

```
#!/usr/bin/env python
import cobrakbase
kbase = cobrakbase.KBaseAPI()
ws = "KBaseMedia"
media = kbase.get_from_ws('Carbon-D-Glucose', ws)
```

I figured out somehow that the Media object in `cobrakbase/core/kbasebiochem/media.py` is not passing the object_type field, while the one in `cobrakbase/core/kbasebiochemmedia.py` does, and if I use the latter, it doesn't fail, but I'm unsure if this is the right object to use for ModelSEEDPy