### PR TITLE
Use .get() for optional subunit fields in FBAModelBuilder

### DIFF
--- a/cobrakbase/core/kbasefba/fbamodel_builder.py
+++ b/cobrakbase/core/kbasefba/fbamodel_builder.py
@@ -241,11 +241,11 @@ class FBAModelBuilder:
                             {x.split("/")[-1] for x in u["feature_refs"]}
                         )
                         notes[f"complex_subunit_features_{role_id}"] = features
-                        notes[f"complex_subunit_note_{role_id}"] = u["note"]
-                        notes[f"complex_subunit_optional_{role_id}"] = u[
-                            "optionalSubunit"
-                        ]
-                        notes[f"complex_subunit_triggering_{role_id}"] = u["triggering"]
+                        notes[f"complex_subunit_note_{role_id}"] = u.get("note", "")
+                        notes[f"complex_subunit_optional_{role_id}"] = u.get(
+                            "optionalSubunit", 0
+                        )
+                        notes[f"complex_subunit_triggering_{role_id}"] = u.get("triggering", 0)
                     complex_group.notes = notes
                     complex_groups[complex_group.id] = complex_group
 


### PR DESCRIPTION
## Summary

`FBAModelBuilder.build()` uses hard key access (`u["optionalSubunit"]`, `u["triggering"]`, `u["note"]`) on `modelReactionProteinSubunits` dicts. Old workspace models may lack these fields, causing `KeyError`.

Changed to `.get()` with sensible defaults:
- `optionalSubunit` → `0` (not optional)
- `triggering` → `0` (not triggering)
- `note` → `""` (empty)

## Context

The KBase FBAModel spec at `data/FBAModel.spec:355-360` defines these fields without `@optional`, but many production models from the PATRIC workspace predate the addition of these fields and lack them.

This is the root cause of https://github.com/ModelSEED/modelseed-api/issues — the modelseed-api currently patches every model before calling `FBAModelBuilder`:

```python
for _rxn in model_obj.get("modelreactions", []):
    for _prot in _rxn.get("modelReactionProteins", []):
        for _sub in _prot.get("modelReactionProteinSubunits", []):
            _sub.setdefault("optionalSubunit", 0)
```

This PR removes the need for that workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)